### PR TITLE
Add code coverage measurement and reporting

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,6 +11,7 @@ on:
       - tox.ini
       - "requirements/**"
       - "docs/**"
+      - ".github/workflows/**"
   workflow_run:
     workflows: ["Update Requirements"]
     types: [completed]
@@ -19,7 +20,9 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    concurrency: ci
+    permissions:
+      contents: write
+    concurrency: ci-${{ github.ref }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +54,43 @@ jobs:
       - name: tests
         run: |
           tox -e ${{ matrix.tox }}
+      - name: coverage-summary
+        run: |
+          echo "## Python coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tox exec -e ${{ matrix.tox }} -- coverage report -m >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          mkdir -p coverage-pages
+          tox exec -e ${{ matrix.tox }} -- coverage xml -o coverage-pages/coverage.xml
+          tox exec -e ${{ matrix.tox }} -- coverage html -d coverage-pages/htmlcov
+      - name: upload-coverage-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.name }}
+          path: coverage-pages/
+      # Warn-only: continue-on-error means this never blocks the job, only shows
+      # as a flagged step.
+      - name: coverage-threshold
+        continue-on-error: true
+        run: tox exec -e ${{ matrix.tox }} -- coverage report --fail-under=0
+      # Written alongside the HTML/XML report so the publish step below carries it
+      # to GitHub Pages - avoids committing to the source branch. Published under
+      # destination_dir: coverage rather than the root, since the docs job below
+      # already publishes to the gh-pages root with no destination_dir of its own -
+      # colliding there would wipe one or the other on every run.
+      - name: coverage-badge
+        continue-on-error: true
+        run: |
+          PCT=$(tox exec -e ${{ matrix.tox }} -- coverage report --format=total | grep -E '^[0-9]+$' | tail -1)
+          COLOR=$(awk -v p="$PCT" 'BEGIN { if (p>=80) print "brightgreen"; else if (p>=50) print "yellow"; else print "red" }')
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' \
+            "$PCT" "$COLOR" > coverage-pages/coverage-badge.json
+      - name: publish-coverage
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage-pages
+          destination_dir: coverage
 
   docs:
     needs: [tests]

--- a/.github/workflows/python-pr.yml
+++ b/.github/workflows/python-pr.yml
@@ -48,3 +48,21 @@ jobs:
               run: pip install tox
             - name: tests
               run: tox -e ${{ matrix.tox }}
+            - name: coverage-summary
+              run: |
+                  echo "## Python coverage" >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  tox exec -e ${{ matrix.tox }} -- coverage report -m >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  tox exec -e ${{ matrix.tox }} -- coverage xml
+                  tox exec -e ${{ matrix.tox }} -- coverage html
+            - name: upload-coverage-artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-report-${{ matrix.name }}
+                  path: |
+                      htmlcov/
+                      coverage.xml
+            - name: coverage-threshold
+              continue-on-error: true
+              run: tox exec -e ${{ matrix.tox }} -- coverage report --fail-under=0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Client
 
 [![Unit tests](https://github.com/sweetrpg/client/actions/workflows/python-ci.yml/badge.svg)](https://github.com/sweetrpg/client/actions/workflows/python-ci.yml)
-[![Coverage](https://github.com/sweetrpg/client/blob/develop/coverage.svg)](https://github.com/sweetrpg/client)
+[![Coverage](https://img.shields.io/endpoint?url=https://sweetrpg.github.io/client.py/coverage/coverage-badge.json)](https://sweetrpg.github.io/client.py/coverage/)
 [![PyPI version](https://badgen.net/pypi/v/sweetrpg-client)](https://pypi.org/project/sweetrpg-client)
 [![License](https://img.shields.io/github/license/sweetrpg/client.svg)](https://img.shields.io/github/license/sweetrpg/client.svg)
 [![Issues](https://img.shields.io/github/issues/sweetrpg/client.svg)](https://img.shields.io/github/issues/sweetrpg/client.svg)


### PR DESCRIPTION
Task 4.1 of the platform-wide code coverage rollout. Same pattern as sweetrpg/api-core.py#1, plus fixes a pre-existing broken README badge (linked a GitHub blob page for a coverage.svg CI never generated).

Refs sweetrpg/platform#3
OpenSpec change: openspec/changes/add-code-coverage/proposal.md (in the platform umbrella repo)