### PR TITLE
Rename sweetrpg-library-objects dependency to shelf-objects

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ flask==3.1.2
     # via
     #   flask-rest-jsonapi
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 flask-rest-jsonapi==0.31.2
     # via sweetrpg-api-core
 frozenlist==1.8.0
@@ -118,14 +118,14 @@ marshmallow==3.26.1
 marshmallow-jsonapi==0.24.0
     # via
     #   flask-rest-jsonapi
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 mdurl==0.1.2
     # via markdown-it-py
 mongoengine==0.29.1
     # via
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 multidict==6.7.0
     # via
     #   aiohttp
@@ -265,19 +265,19 @@ sqlalchemy==2.0.43
 sweetrpg-api-core==0.0.342
     # via
     #   -r requirements/pkg.in
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 sweetrpg-db==0.0.145
     # via
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
-sweetrpg-library-objects==0.0.452
+    #   sweetrpg-shelf-objects
+sweetrpg-shelf-objects==0.0.452
     # via -r requirements/pkg.in
 sweetrpg-model-core==0.0.155
     # via
     #   -r requirements/pkg.in
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 tox==4.30.3
     # via -r requirements/tests.in
 typer==0.19.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -44,7 +44,7 @@ flask==3.1.2
     # via
     #   flask-rest-jsonapi
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 flask-rest-jsonapi==0.31.2
     # via sweetrpg-api-core
 frozenlist==1.8.0
@@ -86,14 +86,14 @@ marshmallow==3.26.1
 marshmallow-jsonapi==0.24.0
     # via
     #   flask-rest-jsonapi
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 mdurl==0.1.2
     # via markdown-it-py
 mongoengine==0.29.1
     # via
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 multidict==6.7.0
     # via
     #   aiohttp
@@ -183,19 +183,19 @@ sqlalchemy==2.0.43
 sweetrpg-api-core==0.0.342
     # via
     #   -r requirements/pkg.in
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 sweetrpg-db==0.0.145
     # via
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
-sweetrpg-library-objects==0.0.452
+    #   sweetrpg-shelf-objects
+sweetrpg-shelf-objects==0.0.452
     # via -r requirements/pkg.in
 sweetrpg-model-core==0.0.155
     # via
     #   -r requirements/pkg.in
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 typer==0.19.2
     # via rstcheck
 typing-extensions==4.15.0

--- a/requirements/pkg.in
+++ b/requirements/pkg.in
@@ -1,6 +1,6 @@
 marshmallow~=3.0
 sweetrpg-api-core
 sweetrpg-model-core
-sweetrpg-library-objects
+sweetrpg-shelf-objects
 requests~=2.0
 jsonapi-client

--- a/requirements/pkg.txt
+++ b/requirements/pkg.txt
@@ -31,7 +31,7 @@ flask==3.1.2
     # via
     #   flask-rest-jsonapi
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 flask-rest-jsonapi==0.31.2
     # via sweetrpg-api-core
 frozenlist==1.8.0
@@ -67,12 +67,12 @@ marshmallow==3.26.1
 marshmallow-jsonapi==0.24.0
     # via
     #   flask-rest-jsonapi
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 mongoengine==0.29.1
     # via
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 multidict==6.7.0
     # via
     #   aiohttp
@@ -107,19 +107,19 @@ sqlalchemy==2.0.43
 sweetrpg-api-core==0.0.342
     # via
     #   -r requirements/pkg.in
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 sweetrpg-db==0.0.145
     # via
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
-sweetrpg-library-objects==0.0.452
+    #   sweetrpg-shelf-objects
+sweetrpg-shelf-objects==0.0.452
     # via -r requirements/pkg.in
 sweetrpg-model-core==0.0.155
     # via
     #   -r requirements/pkg.in
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 typing-extensions==4.15.0
     # via
     #   aiosignal

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -53,7 +53,7 @@ flask==3.1.2
     # via
     #   flask-rest-jsonapi
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 flask-rest-jsonapi==0.31.2
     # via sweetrpg-api-core
 frozenlist==1.8.0
@@ -93,12 +93,12 @@ marshmallow==3.26.1
 marshmallow-jsonapi==0.24.0
     # via
     #   flask-rest-jsonapi
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 mongoengine==0.29.1
     # via
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 multidict==6.7.0
     # via
     #   aiohttp
@@ -170,19 +170,19 @@ sqlalchemy==2.0.43
 sweetrpg-api-core==0.0.342
     # via
     #   -r requirements/pkg.in
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 sweetrpg-db==0.0.145
     # via
     #   sweetrpg-api-core
-    #   sweetrpg-library-objects
-sweetrpg-library-objects==0.0.452
+    #   sweetrpg-shelf-objects
+sweetrpg-shelf-objects==0.0.452
     # via -r requirements/pkg.in
 sweetrpg-model-core==0.0.155
     # via
     #   -r requirements/pkg.in
     #   sweetrpg-api-core
     #   sweetrpg-db
-    #   sweetrpg-library-objects
+    #   sweetrpg-shelf-objects
 tox==4.30.3
     # via -r requirements/tests.in
 typing-extensions==4.15.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         "marshmallow==3.14.1",
         "sweetrpg-model-core",
         "sweetrpg-api-core",
-        "sweetrpg-library-objects",
+        "sweetrpg-shelf-objects",
         "requests",
         "jsonapi-client"
     ],

--- a/src/sweetrpg_client/types/registry.py
+++ b/src/sweetrpg_client/types/registry.py
@@ -5,22 +5,22 @@ __author__ = "Paul Schifferer <dm@sweetrpg.com>"
 
 from ..constants import *
 from ..types import *
-from sweetrpg_library_objects.api.volume.schema import VolumeAPISchema
-from sweetrpg_library_objects.api.license.schema import LicenseAPISchema
-from sweetrpg_library_objects.api.person.schema import PersonAPISchema
-from sweetrpg_library_objects.api.contribution.schema import ContributionAPISchema
-from sweetrpg_library_objects.api.publisher.schema import PublisherAPISchema
-from sweetrpg_library_objects.api.studio.schema import StudioAPISchema
-from sweetrpg_library_objects.api.system.schema import SystemAPISchema
-from sweetrpg_library_objects.api.review.schema import ReviewAPISchema
-from sweetrpg_library_objects.model.volume import Volume
-from sweetrpg_library_objects.model.person import Person
-from sweetrpg_library_objects.model.contribution import Contribution
-from sweetrpg_library_objects.model.publisher import Publisher
-from sweetrpg_library_objects.model.system import System
-from sweetrpg_library_objects.model.studio import Studio
-from sweetrpg_library_objects.model.review import Review
-from sweetrpg_library_objects.model.license import License
+from sweetrpg_shelf_objects.api.volume.schema import VolumeAPISchema
+from sweetrpg_shelf_objects.api.license.schema import LicenseAPISchema
+from sweetrpg_shelf_objects.api.person.schema import PersonAPISchema
+from sweetrpg_shelf_objects.api.contribution.schema import ContributionAPISchema
+from sweetrpg_shelf_objects.api.publisher.schema import PublisherAPISchema
+from sweetrpg_shelf_objects.api.studio.schema import StudioAPISchema
+from sweetrpg_shelf_objects.api.system.schema import SystemAPISchema
+from sweetrpg_shelf_objects.api.review.schema import ReviewAPISchema
+from sweetrpg_shelf_objects.model.volume import Volume
+from sweetrpg_shelf_objects.model.person import Person
+from sweetrpg_shelf_objects.model.contribution import Contribution
+from sweetrpg_shelf_objects.model.publisher import Publisher
+from sweetrpg_shelf_objects.model.system import System
+from sweetrpg_shelf_objects.model.studio import Studio
+from sweetrpg_shelf_objects.model.review import Review
+from sweetrpg_shelf_objects.model.license import License
 
 
 _types = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,8 +8,8 @@ from sweetrpg_client.client import Client
 from sweetrpg_client.types import VOLUME, PERSON
 import os
 import json
-from sweetrpg_library_objects.model.volume import Volume
-from sweetrpg_library_objects.model.person import Person
+from sweetrpg_shelf_objects.model.volume import Volume
+from sweetrpg_shelf_objects.model.person import Person
 from sweetrpg_client.exceptions import *
 
 def test_client():


### PR DESCRIPTION
Consumer-side rename: this package's type registry (`src/sweetrpg_client/types/registry.py`) imports directly from `sweetrpg_library_objects` to build Volume/License/Person/Publisher/Studio/System/Review schemas - only `shelf-web` (formerly `library-web`) actually depends on this package.

`sweetrpg-shelf-objects` isn't published yet - the Shelf domain model hasn't been designed - so this dependency won't resolve until that design work happens. Expected to stay broken in the meantime, consistent with `shelf-api`/`shelf-web`.

Part of task group 3 (consumer audit) in the linked OpenSpec change.

Ref: sweetrpg/platform#11
OpenSpec change: `openspec/changes/rename-library-to-shelf/proposal.md` (in sweetrpg/platform)