### PR TITLE
fix(client): propagate traceparent context and use structured logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         "sweetrpg-api-core",
         "sweetrpg-shelf-objects",
         "requests",
-        "jsonapi-client"
+        "jsonapi-client",
+        "opentelemetry-api",
     ],
     extras_require={},
 )

--- a/src/sweetrpg_client/client.py
+++ b/src/sweetrpg_client/client.py
@@ -15,7 +15,7 @@ from jsonapi_client import Session
 from sweetrpg_client.helpers import _flatten_object
 
 
-__logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class Client(object):
@@ -57,20 +57,20 @@ class Client(object):
         :param str id:
         :return Model:
         """
-        __logger.debug("Fetching data type %s ID %s...", data_type, id)
+        _logger.debug("Fetching data type %s ID %s...", data_type, id)
 
         type_info = self.data_types.get(data_type)
-        __logger.debug("type_info: %s", type_info)
+        _logger.debug("type_info: %s", type_info)
         if not type_info:
             raise UnknownDataType(data_type)
 
         path = type_info[constants.ENDPOINT_PATH]
-        __logger.debug("path: %s", path)
+        _logger.debug("path: %s", path)
         # url = f"{self.base_url}/{path}/{id}"
-        # __logger.debug("url: %s", url)
+        # _logger.debug("url: %s", url)
         headers = {}
         if self.access_token:
-            __logger.debug("adding access token to request headers")
+            _logger.debug("adding access token to request headers")
             headers['Authorization'] = f"Bearer {self.access_token}"
 
         propagate.inject(headers)
@@ -80,7 +80,7 @@ class Client(object):
             # 'params': params,
         }
 
-        __logger.info("Sending request to %s...", self.base_url)
+        _logger.info("Sending request to %s...", self.base_url)
 
         with Session(self.base_url, request_kwargs=request_args) as s:
             result = s.get(path, id)
@@ -91,9 +91,9 @@ class Client(object):
 
             flat_obj = _flatten_object(result.resource)
             obj_class = type_info[constants.OBJECT_CLASS]
-            __logger.debug("obj_class: %s", obj_class)
+            _logger.debug("obj_class: %s", obj_class)
             obj = obj_class(**flat_obj)
-            __logger.debug("obj: %s", obj)
+            _logger.debug("obj: %s", obj)
             return obj
 
     def query(self, data_type: str, page: int = 0, limit: int = constants.DEFAULT_PAGE_SIZE) -> list:
@@ -104,20 +104,20 @@ class Client(object):
         :param limit:
         :return list[Model]:
         """
-        __logger.debug("Querying for data type %s, page %d, limit %d...", data_type, page, limit)
+        _logger.debug("Querying for data type %s, page %d, limit %d...", data_type, page, limit)
 
         type_info = self.data_types.get(data_type)
-        __logger.debug("type_info: %s", type_info)
+        _logger.debug("type_info: %s", type_info)
         if not type_info:
             raise UnknownDataType(data_type)
 
         path = type_info[constants.ENDPOINT_PATH]
-        __logger.debug("path: %s", path)
+        _logger.debug("path: %s", path)
         # url = f"{self.base_url}/{path}/"
-        # __logger.debug("url: %s", url)
+        # _logger.debug("url: %s", url)
         headers = {}
         if self.access_token:
-            __logger.debug("adding access token to request headers")
+            _logger.debug("adding access token to request headers")
             headers['Authorization'] = f"Bearer {self.access_token}"
         params = {}
         if page > 0:
@@ -132,7 +132,7 @@ class Client(object):
             'params': params,
         }
 
-        __logger.info("Sending request to %s...", self.base_url)
+        _logger.info("Sending request to %s...", self.base_url)
 
         with Session(self.base_url, request_kwargs=request_args) as s:
             result = s.get(path)
@@ -143,9 +143,9 @@ class Client(object):
 
             flat_objs = list(map(_flatten_object, result.resources))
             obj_class = type_info[constants.OBJECT_CLASS]
-            __logger.debug("obj_class: %s", obj_class)
+            _logger.debug("obj_class: %s", obj_class)
             objs = list(map(lambda o: obj_class(**o), flat_objs))
-            __logger.debug("objs: %s", objs)
+            _logger.debug("objs: %s", objs)
             return objs
 
         # r = requests.get(url, headers=headers, params=params)

--- a/src/sweetrpg_client/client.py
+++ b/src/sweetrpg_client/client.py
@@ -5,6 +5,7 @@ __author__ = "Paul Schifferer <dm@sweetrpg.com>"
 
 import logging
 import requests
+from opentelemetry import propagate
 from sweetrpg_client import constants
 from sweetrpg_client.exceptions import *
 from sweetrpg_client.types import *
@@ -12,6 +13,9 @@ from sweetrpg_client.types.registry import _types
 from sweetrpg_model_core.model.base import Model
 from jsonapi_client import Session
 from sweetrpg_client.helpers import _flatten_object
+
+
+__logger = logging.getLogger(__name__)
 
 
 class Client(object):
@@ -53,28 +57,30 @@ class Client(object):
         :param str id:
         :return Model:
         """
-        logging.debug("Fetching data type %s ID %s...", data_type, id)
+        __logger.debug("Fetching data type %s ID %s...", data_type, id)
 
         type_info = self.data_types.get(data_type)
-        logging.debug("type_info: %s", type_info)
+        __logger.debug("type_info: %s", type_info)
         if not type_info:
             raise UnknownDataType(data_type)
 
         path = type_info[constants.ENDPOINT_PATH]
-        logging.debug("path: %s", path)
+        __logger.debug("path: %s", path)
         # url = f"{self.base_url}/{path}/{id}"
-        # logging.debug("url: %s", url)
+        # __logger.debug("url: %s", url)
         headers = {}
         if self.access_token:
-            logging.debug("adding access token to request headers")
+            __logger.debug("adding access token to request headers")
             headers['Authorization'] = f"Bearer {self.access_token}"
+
+        propagate.inject(headers)
 
         request_args = {
             'headers': headers,
             # 'params': params,
         }
 
-        logging.info("Sending request to %s...", self.base_url)
+        __logger.info("Sending request to %s...", self.base_url)
 
         with Session(self.base_url, request_kwargs=request_args) as s:
             result = s.get(path, id)
@@ -85,9 +91,9 @@ class Client(object):
 
             flat_obj = _flatten_object(result.resource)
             obj_class = type_info[constants.OBJECT_CLASS]
-            logging.debug("obj_class: %s", obj_class)
+            __logger.debug("obj_class: %s", obj_class)
             obj = obj_class(**flat_obj)
-            logging.debug("obj: %s", obj)
+            __logger.debug("obj: %s", obj)
             return obj
 
     def query(self, data_type: str, page: int = 0, limit: int = constants.DEFAULT_PAGE_SIZE) -> list:
@@ -98,20 +104,20 @@ class Client(object):
         :param limit:
         :return list[Model]:
         """
-        logging.debug("Querying for data type %s, page %d, limit %d...", data_type, page, limit)
+        __logger.debug("Querying for data type %s, page %d, limit %d...", data_type, page, limit)
 
         type_info = self.data_types.get(data_type)
-        logging.debug("type_info: %s", type_info)
+        __logger.debug("type_info: %s", type_info)
         if not type_info:
             raise UnknownDataType(data_type)
 
         path = type_info[constants.ENDPOINT_PATH]
-        logging.debug("path: %s", path)
+        __logger.debug("path: %s", path)
         # url = f"{self.base_url}/{path}/"
-        # logging.debug("url: %s", url)
+        # __logger.debug("url: %s", url)
         headers = {}
         if self.access_token:
-            logging.debug("adding access token to request headers")
+            __logger.debug("adding access token to request headers")
             headers['Authorization'] = f"Bearer {self.access_token}"
         params = {}
         if page > 0:
@@ -119,12 +125,14 @@ class Client(object):
         if limit != constants.DEFAULT_PAGE_SIZE:
             params[constants.LIMIT_PARAM] = min(max(limit, 1), constants.MAX_PAGE_SIZE)
 
+        propagate.inject(headers)
+
         request_args = {
             'headers': headers,
             'params': params,
         }
 
-        logging.info("Sending request to %s...", self.base_url)
+        __logger.info("Sending request to %s...", self.base_url)
 
         with Session(self.base_url, request_kwargs=request_args) as s:
             result = s.get(path)
@@ -135,9 +143,9 @@ class Client(object):
 
             flat_objs = list(map(_flatten_object, result.resources))
             obj_class = type_info[constants.OBJECT_CLASS]
-            logging.debug("obj_class: %s", obj_class)
+            __logger.debug("obj_class: %s", obj_class)
             objs = list(map(lambda o: obj_class(**o), flat_objs))
-            logging.debug("objs: %s", objs)
+            __logger.debug("objs: %s", objs)
             return objs
 
         # r = requests.get(url, headers=headers, params=params)

--- a/src/sweetrpg_client/helpers.py
+++ b/src/sweetrpg_client/helpers.py
@@ -6,20 +6,23 @@ __author__ = "Paul Schifferer <dm@sweetrpg.com>"
 import logging
 
 
+__logger = logging.getLogger(__name__)
+
+
 def _flatten_object(obj):
     """
 
     """
-    logging.debug("obj: %s", obj)
+    __logger.debug("obj: %s", obj)
 
     fields = list(filter(lambda s: not s.startswith('_'), dir(obj.fields)))
-    logging.debug("fields: %s", fields)
+    __logger.debug("fields: %s", fields)
     flattened = {'id': obj.id}
     for k in fields:
         try:
             flattened[k] = obj.attributes[k]
         except:
-            logging.debug(f"value not found for key {k} in object {obj}")
-    logging.debug("flattened: %s", flattened)
+            __logger.debug("value not found for key %s in object %s", k, obj)
+    __logger.debug("flattened: %s", flattened)
 
     return flattened


### PR DESCRIPTION
## Summary
- Inject W3C traceparent headers via opentelemetry-api on outgoing requests so calling services' spans link across the HTTP hop
- Replace ad-hoc logging.debug/info calls with a module-level logger so consuming services' structured JSON log handlers pick these lines up

## Test plan
- [x] Syntax/import validated
- [x] Existing test suite passes with mocked responses